### PR TITLE
ci: use sha pinning to mitigate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1.298.0
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: unit testing


### PR DESCRIPTION
Lower risk about supply chain attack even though matched tag was compromised.