### PR TITLE
test: restore router after run to fix specs on fluentd v1.19.3

### DIFF
--- a/spec/out_stats_spec.rb
+++ b/spec/out_stats_spec.rb
@@ -6,6 +6,16 @@ class Fluent::Test::OutputTestDriver
     @tag = tag if tag
     emit(record, time)
   end
+
+  # Since fluentd v1.19.3, TestDriver#run invokes the full shutdown lifecycle
+  # (after_shutdown/close/terminate), each of which resets the plugin's router
+  # to nil. These specs call flush_emit after run, so restore the router to
+  # keep router.emit working.
+  def run(*args, &block)
+    super
+  ensure
+    instance.router = Fluent::Engine.root_agent.event_router
+  end
 end
 
 describe Fluent::StatsOutput do


### PR DESCRIPTION
Since fluentd v1.19.3, Fluent::Test::TestDriver#run runs the full shutdown lifecycle (after_shutdown/close/terminate) in its ensure block, and each of those resets the plugin's router to nil in PluginHelper::EventEmitter.

Our specs call driver.instance.flush_emit after driver.run returns, so router.emit raised "undefined method 'emit' for nil". Override run in the OutputTestDriver monkey-patch to restore the router after teardown.

Related to https://github.com/fluent-plugins-nursery/fluent-plugin-grepcounter/pull/32